### PR TITLE
add nd integration to project probability onto one dimension using si…

### DIFF
--- a/trikde/kde.py
+++ b/trikde/kde.py
@@ -101,10 +101,13 @@ class LinearKDE(PointInterp):
     def __init__(self, nbins, nbins_eval, resampling=True, n_resample=100000, sharing_interp = False):
         """
 
-        :param nbins:
-        :param nbins_eval:
-        :param resampling:
-        :param n_resample:
+        :param nbins: number of bins to estimate the pdf originally
+        :param nbins_eval: final number of bins to evaluate the pdf on
+        :param resampling: if True, randomly draws from a linear interpolation of the nbins points, and then re-bins on n_eval bins
+                          if False, default is a map coordinates interpolation of nbins, evaluated at n_eval bins
+        :param n_resample: number of points to resample the pdf, used if resampling True
+        :param sharing_interp: used if resampling is False, divides probability evenly onto subsampled pixels returns final
+        resolution of nbins_eval
         """
         self._nbins_eval = nbins_eval
         self._resampling = resampling

--- a/trikde/pdfs.py
+++ b/trikde/pdfs.py
@@ -125,6 +125,11 @@ class InterpolatedLikelihood(object):
         Currently integrates over the entire prior on the other axes.
         :param final_axis_index: index of the axis to project onto (int)
         :param nbins: number of points to divide each axis into. Assumes the same for all three. Could be changed if desired.
+        :param method: integration method either simps or trapz
+        :param normalize: whether or not to normalize the posterior distribution
+        :param eval_points: if not None, will evaluate the posterior distribution at the points determined by nbins divided over param ranges
+
+        Returns the marginal distribution as a 1D array of values, along the points that it was evaluated at.
         """
         bin_centers = self.get_bins(nbins)
 
@@ -137,10 +142,19 @@ class InterpolatedLikelihood(object):
         return eval_points, projected_values
 
     def integrate_projection(self, all_bin_centers, project_axis, eval_points, method='simps', normalize=True):
+        """
+        Does the n-d integration given an interpolator object, returns the marginal distribution along one axis
+        :param all_bin_centers: the bins to project onto (list)
+        :param project_axis: the axis to project onto (int)
+        :eval_points: the points to evaluate (list) this is where the marginal distribution will be evaluated
+        :param method: integration method either simps or trapz
+        :param normalize: whether or not to normalize the posterior distribution
+
+        Return the marginal distribution as a 1D array of values, along the points that it was evaluated at.
+        """
+
 
         interpolator=self.interp
-
-
 
         ndim = len(all_bin_centers)
         axes_to_integrate = []


### PR DESCRIPTION
…mpson integration

This is much faster than the current rejection sampling of the posterior. I've verified that it returns consistent results.

Usage is:
interpolated_likelihood = trikde.pdfs.InterpolatedLikelihood(joint_likelihood, param_names_dm, param_ranges_dm_list)

hmm_bin_cens, numerical_integral = interpolated_likelihood.project_onto_axis(1, inal_axis_index,nbins, method='simps',normalize=True, eval_points = None)

n_bins is the number of points where you're computing the integration in each dimension, there is an option to only evaluate the integral at eval_points rather than across the entire spam of param_ranges. The integrated dimensions are always evaluated across the whole range.

